### PR TITLE
ci: fix goreleaser not login into docker

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,12 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
 
+      - name: Docker Login
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          echo "${GITHUB_TOKEN}" | docker login ghcr.io --username $GITHUB_ACTOR --password-stdin
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:


### PR DESCRIPTION
Attempt at fixing 

```
⨯ release failed after 36.36s error=docker images: failed to publish artifacts: failed to push docker image: 
The push refers to repository [ghcr.io/nivl/voorhees]
270be51c337c: Preparing
denied: unauthenticated: User cannot be authenticated with the token provided.
```